### PR TITLE
Run PHPCsFixer in a path relative to root directory

### DIFF
--- a/src/LIN3S/CS/.php_cs.dist
+++ b/src/LIN3S/CS/.php_cs.dist
@@ -14,7 +14,7 @@ declare(strict_types=1);
 use LIN3S\PhpCsFixerConfig\Lin3sConfig;
 
 $config = new Lin3sConfig('$$CHANGE-FOR-YOUR-AWESOME-NAME CHANGE-FOR-TYPE$$', '$$CHANGE-FOR-YEAR$$', '$$CHANGE-FOR-TYPE$$');
-$config->getFinder()->in(__DIR__ . '$$CHANGE-FOR-PHPCSFIXER-PATH$$');
+$config->getFinder()->in('$$CHANGE-FOR-PHPCSFIXER-PATH$$');
 
 $cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
 

--- a/src/LIN3S/CS/.phpspec_cs.dist
+++ b/src/LIN3S/CS/.phpspec_cs.dist
@@ -14,7 +14,7 @@ declare(strict_types=1);
 use LIN3S\PhpCsFixerConfig\Lin3sConfig;
 
 $config = new Lin3sConfig('$$CHANGE-FOR-YOUR-AWESOME-NAME CHANGE-FOR-TYPE$$', '$$CHANGE-FOR-YEAR$$', '$$CHANGE-FOR-TYPE$$', true);
-$config->getFinder()->in(__DIR__ . '$$CHANGE-FOR-PHPCSFIXER-TEST-PATH$$')->name('*Spec.php');
+$config->getFinder()->in('$$CHANGE-FOR-PHPCSFIXER-TEST-PATH$$')->name('*Spec.php');
 
 $cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
 

--- a/src/LIN3S/CS/Checker/PhpCsFixer.php
+++ b/src/LIN3S/CS/Checker/PhpCsFixer.php
@@ -91,12 +91,12 @@ final class PhpCsFixer implements Checker
         );
         $file = str_replace(
             '$$CHANGE-FOR-PHPCSFIXER-PATH$$',
-            '/' . $parameters['phpcsfixer_path'],
+            $parameters['root_directory'] . '/' . $parameters['phpcsfixer_path'],
             $file
         );
         $file = str_replace(
             '$$CHANGE-FOR-PHPCSFIXER-TEST-PATH$$',
-            '/' . $parameters['phpcsfixer_test_path'],
+            $parameters['root_directory'] . '/' . $parameters['phpcsfixer_test_path'],
             $file
         );
 


### PR DESCRIPTION
Related to #6.

Issues appear when `lin3s_cs.yml` is located at project root and the PHP CS Fixer configuration is relative to that file but php_cs is not in the same directory as happens in #6.

Have some doubts though, maybe adding an example lin3s_cs.yml to the docs should be enough as adding `phpcsfixer_file_location: ''` solves the problem